### PR TITLE
Add knowledge-base pointers (README header + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Working in this repo — ds-aa-tcd-drought
+
+<!-- markdownlint-disable MD013 -->
+
+This repo is the **spoke** for the knowledge-base page
+**[`frameworks/tcd-drought/2025-03-03.md`](https://github.com/OCHA-DAP/ds-knowledge-base/blob/main/frameworks/tcd-drought/2025-03-03.md)**
+(the **hub**, in
+[OCHA-DAP/ds-knowledge-base](https://github.com/OCHA-DAP/ds-knowledge-base)).
+
+## Before you work
+
+1. **Read the KB page** above — it carries the authoritative trigger, the
+   reconciliation / `discrepancies`, funding, monitoring, and how this
+   framework fits the portfolio. Don't re-derive what's already summarised.
+2. Skim the KB conventions: `INGESTION.md` and `docs/DESIGN.md` in the KB repo.
+3. **Work is usually NOT on `main`.** The active branch is **`2025-monitoring`**
+   (`main` is ~3 months stale). The KB page's `source_branch` is the source of
+   truth for which branch to read.
+
+## Authority & where the trigger lives
+
+- The **latest framework PDF**
+  ([2025-03-03](https://www.unocha.org/publications/report/chad/cadre-de-laction-anticipatoire-secheresse-au-tchad-version-finale-du-3-mars-2025))
+  is authoritative for the trigger; this repo *derives/implements* it. If code
+  and PDF disagree, the **PDF wins** and the gap is a `discrepancy` on the KB
+  page.
+- Canonical trigger code: `analysis/combined_rp_2025.md`,
+  `analysis/monitoring_2025_seas5.md`, `analysis/monitoring_2025_biomasse.md`,
+  `src/constants.py`, `src/datasources/{seas5,biomasse}.py`.
+- ⚠️ The README **Overview** still links the old 2022 PDF and
+  `pa-anticipatory-action`; the KB header supersedes it.
+
+## After real work
+
+**Capture-as-you-go:** if you change the trigger, thresholds, or monitoring,
+update the KB page (and this file if the repo's orientation changed). The KB
+stays useful only if work flows back into it.
+
+## Team conventions
+
+Follow the team's global config (`~/.claude/CLAUDE.dsci.md`): `ocha-stratus`
+for all blob/DB access, `ocha-lens` for common processing, marimo for apps,
+`PROJECT_PREFIX` from `src.constants`. Note: **`ocha-anticipy` is deprecated**
+— relevant for reading older frameworks, but not used for new work.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 
 <!-- KB-POINTER:START (generated from the knowledge base — edit there, not here) -->
 <!-- markdownlint-disable MD013 -->
-> **📚 Knowledge base — read this first:** **[`frameworks/tcd-drought`](https://github.com/OCHA-DAP/ds-knowledge-base/blob/main/frameworks/tcd-drought/2025-03-03.md)** in [OCHA-DAP/ds-knowledge-base](https://github.com/OCHA-DAP/ds-knowledge-base) — the authoritative summary of the trigger, calibration, discrepancies, funding, and how this framework fits the AA portfolio.
+> **📚 This framework in the team knowledge base** →
+> **[ds-knowledge-base › `frameworks/tcd-drought`](https://github.com/OCHA-DAP/ds-knowledge-base/blob/main/frameworks/tcd-drought/2025-03-03.md)**
+>
+> A *separate*, central repo that **summarizes and compares** every OCHA AA framework. Go there for the trigger, calibration, discrepancies, and portfolio context — then come **back here** for the analysis and code, which are the source of truth.
 
-| | |
+| at a glance | |
 |---|---|
 | **Status** | endorsed |
 | **Current version** | 2025-03-03 ([framework PDF](https://www.unocha.org/publications/report/chad/cadre-de-laction-anticipatoire-secheresse-au-tchad-version-finale-du-3-mars-2025)) — supersedes 2022-10-24 |
 | **Active branch** | [`2025-monitoring`](https://github.com/OCHA-DAP/ds-aa-tcd-drought/tree/2025-monitoring) — ⚠️ `main` is stale; current work lives here |
-| **Trigger code** | `analysis/combined_rp_2025.md`, `analysis/monitoring_2025_*.md`, `src/constants.py`, `src/datasources/` |
+| **Canonical trigger code** | `analysis/combined_rp_2025.md`, `analysis/monitoring_2025_*.md`, `src/constants.py`, `src/datasources/` |
 
-_One home per fact: the trigger logic is the **code** + the **KB page**; this README points, it doesn't restate. Working here with Claude? See [`CLAUDE.md`](CLAUDE.md)._
+_The knowledge base **points and compares**; this repo **is the source of truth** for the analysis. Working here with Claude? See [`CLAUDE.md`](CLAUDE.md)._
 
 <!-- kb-page: frameworks/tcd-drought/2025-03-03.md -->
 <!-- kb-repo: OCHA-DAP/ds-knowledge-base -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 [![Generic badge](https://img.shields.io/badge/STATUS-ENDORSED-%231EBFB3)](https://shields.io/)
 
+<!-- KB-POINTER:START (generated from the knowledge base — edit there, not here) -->
+<!-- markdownlint-disable MD013 -->
+> **📚 Knowledge base — read this first:** **[`frameworks/tcd-drought`](https://github.com/OCHA-DAP/ds-knowledge-base/blob/main/frameworks/tcd-drought/2025-03-03.md)** in [OCHA-DAP/ds-knowledge-base](https://github.com/OCHA-DAP/ds-knowledge-base) — the authoritative summary of the trigger, calibration, discrepancies, funding, and how this framework fits the AA portfolio.
+
+| | |
+|---|---|
+| **Status** | endorsed |
+| **Current version** | 2025-03-03 ([framework PDF](https://www.unocha.org/publications/report/chad/cadre-de-laction-anticipatoire-secheresse-au-tchad-version-finale-du-3-mars-2025)) — supersedes 2022-10-24 |
+| **Active branch** | [`2025-monitoring`](https://github.com/OCHA-DAP/ds-aa-tcd-drought/tree/2025-monitoring) — ⚠️ `main` is stale; current work lives here |
+| **Trigger code** | `analysis/combined_rp_2025.md`, `analysis/monitoring_2025_*.md`, `src/constants.py`, `src/datasources/` |
+
+_One home per fact: the trigger logic is the **code** + the **KB page**; this README points, it doesn't restate. Working here with Claude? See [`CLAUDE.md`](CLAUDE.md)._
+
+<!-- kb-page: frameworks/tcd-drought/2025-03-03.md -->
+<!-- kb-repo: OCHA-DAP/ds-knowledge-base -->
+<!-- markdownlint-enable MD013 -->
+<!-- KB-POINTER:END -->
+
 ## Overview
 
 This repository contains recent analysis for the


### PR DESCRIPTION
Prototype of the **per-repo spoke→hub pointers** for the team [knowledge base](https://github.com/OCHA-DAP/ds-knowledge-base). This is the pattern we'd fan out to every framework/pipeline repo — reviewing it here first.

## What this adds
- **README header block** (between the badge and Overview): a standardized `KB-POINTER` panel linking the [KB page](https://github.com/OCHA-DAP/ds-knowledge-base/blob/main/frameworks/tcd-drought/2025-03-03.md), with status, current version + **2025** framework PDF, the **active branch** (`2025-monitoring` — `main` is stale), and the trigger code paths.
- **`CLAUDE.md`**: agent-facing orientation so a Claude working in this repo reads the KB page first, knows the PDF is authoritative for the trigger, knows work isn't on `main`, and writes changes back to the KB (capture-as-you-go).
- **Machine markers** (`<!-- kb-page -->`, `<!-- KB-POINTER:START/END -->`) so the block can be regenerated and so a drift job can check repo↔KB both ways.

## Design choices to react to
- **Append, don't clobber** — the existing Overview/Development sections are untouched. (Note it still links the *2022* PDF + `pa-anticipatory-action`; the KB header is the corrected pointer. Want me to also fix the body, or leave human content alone?)
- **Generated, not hand-written** — both blocks derive from the KB page frontmatter; the plan is a generator + a PR per repo, not hand-editing 100+ READMEs.
- **markdownlint** — scoped `MD013` (80-char) disable to just the generated blocks rather than relaxing it repo-wide. Reasonable?
- **Target branch** — opened against `main` (the README people see on GitHub); the header names the real active branch. OK, or prefer it on the active branch?

No code changes; docs only.